### PR TITLE
Add --scale option

### DIFF
--- a/chez-grater.cabal
+++ b/chez-grater.cabal
@@ -109,6 +109,7 @@ executable chez-grater
     , aeson-pretty < 0.9
     , base < 5.0
     , bytestring < 0.12
+    , case-insensitive < 1.3
     , network-uri < 2.7
     , optparse-applicative < 0.18
     , text < 1.3

--- a/chez-grater.cabal
+++ b/chez-grater.cabal
@@ -121,6 +121,7 @@ test-suite tests
   main-is: main.hs
   other-modules:
       Chez.Grater.ParserSpec
+      Chez.Grater.ReadableSpec
       Chez.Grater.TestEnv
       Chez.GraterSpec
       Paths_chez_grater

--- a/test/Chez/Grater/ReadableSpec.hs
+++ b/test/Chez/Grater/ReadableSpec.hs
@@ -1,0 +1,32 @@
+module Chez.Grater.ReadableSpec where
+
+import Chez.Grater.Internal.Prelude
+
+import Chez.Grater.Types (Quantity(..))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+-- the module being tested
+import Chez.Grater.Readable.Types
+
+spec :: Spec
+spec = describe "Readable" $ do
+  describe "Quantity" $ do
+    it "shows 1" $
+      (showReadableQuantity . mkReadableQuantity) (Quantity 1)
+        `shouldBe` Just "1"
+    it "shows 1/2" $
+      (showReadableQuantity . mkReadableQuantity) (Quantity 0.5)
+        `shouldBe` Just "1/2"
+    it "shows 1 1/4" $
+      (showReadableQuantity . mkReadableQuantity) (Quantity 1.25)
+        `shouldBe` Just "1 1/4"
+    it "shows 3/8" $
+      (showReadableQuantity . mkReadableQuantity) (Quantity 0.375)
+        `shouldBe` Just "3/8"
+    it "shows some other odd quantity" $
+      (showReadableQuantity . mkReadableQuantity) (Quantity 7/11)
+        `shouldBe` Just "0.636"
+
+    it "can't show missing" $
+      (showReadableQuantity . mkReadableQuantity) QuantityMissing
+        `shouldBe` Nothing

--- a/test/Chez/Grater/ReadableSpec.hs
+++ b/test/Chez/Grater/ReadableSpec.hs
@@ -23,9 +23,12 @@ spec = describe "Readable" $ do
     it "shows 3/8" $
       (showReadableQuantity . mkReadableQuantity) (Quantity 0.375)
         `shouldBe` Just "3/8"
-    it "shows some other odd quantity" $
-      (showReadableQuantity . mkReadableQuantity) (Quantity 7/11)
-        `shouldBe` Just "0.636"
+    it "shows 7/9" $
+      (showReadableQuantity . mkReadableQuantity) (Quantity 7/9)
+        `shouldBe` Just "7/9"
+    it "shows (an approximation of) 1 13/100" $
+      (showReadableQuantity . mkReadableQuantity) (Quantity 113/100)
+        `shouldBe` Just "1 3/23"
 
     it "can't show missing" $
       (showReadableQuantity . mkReadableQuantity) QuantityMissing

--- a/test/main.hs
+++ b/test/main.hs
@@ -3,6 +3,7 @@ import Prelude
 import Chez.Grater.TestEnv (loadEnv)
 import Test.Hspec (hspec)
 import qualified Chez.Grater.ParserSpec
+import qualified Chez.Grater.ReadableSpec
 import qualified Chez.GraterSpec
 
 main :: IO ()
@@ -10,4 +11,5 @@ main = do
   env <- loadEnv
   hspec $ do
     Chez.Grater.ParserSpec.spec
+    Chez.Grater.ReadableSpec.spec
     Chez.GraterSpec.spec env


### PR DESCRIPTION
For example:

```
$ stack run chez-grater -- --scale "1 1/2"  https://cooking.nytimes.com/recipes/1020384-tomato-cobbler-with-ricotta-biscuits
Tomato Cobbler With Ricotta Biscuits Recipe - NYT Cooking
---------------------------------------------------------
1 cup whole-milk ricotta
3 3/4 cup /320 grams plus 2 tablespoons cake flour, plus more for dusting
1 1/2 tbsp plus 1/4 cup/50 grams granulated sugar
(1 1/2x) Kosher salt and freshly ground black pepper
2 1/4 tsp baking powder
1 1/2 tsp baking soda
3/4 cup /115 grams unsalted butter (1 stick), cut into cubes and chilled
1 1/2 cup /240 milliliters buttermilk, plus 2 tablespoons for brushing
3 to 2 ½ pounds cherry tomatoes or Sungold tomatoes
cup /60 milliliters extra-virgin olive oil
1 1/2 tbsp sherry vinegar
3 sprigs fresh thyme
---------------------------------------------------------
...
```

I think this is rather useful, actually 😄

Can you spot the bug above?